### PR TITLE
improvement(std): use a general clock even in std environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ automatically from the crate internals with `std::time::SystemTime`.
 use timed_map::TimedMap;
 use std::time::Duration;
 
-let mut map: TimedMap<_, _> = TimedMap::new();
+let mut map = TimedMap::new();
 
 map.insert_expirable(1, "expirable value", Duration::from_secs(60));
 assert_eq!(map.get(&1), Some(&"expirable value"));
@@ -65,7 +65,7 @@ This is only available on `std` environments.
 ```rs
 use timed_map::{MapKind, TimedMap};
 
-let mut map: TimedMap<_, _> = TimedMap::new_with_map_kind(MapKind::FxHashMap);
+let mut map = TimedMap::new_with_map_kind(MapKind::FxHashMap);
 ```
 
 #### Manual Expiration Control
@@ -74,7 +74,7 @@ To have fully control over expired entries, use the `*_unchecked` functions and 
 This can boost performance by running expiration logic only when it's necessary to maximize the performance.
 
 ```rs
-let mut map: TimedMap<_, _> = TimedMap::new();
+let mut map = TimedMap::new();
 
 map.insert_expirable_unchecked(1, "expirable value", Duration::from_secs(60));
 assert_eq!(map.get_unchecked(&1), Some(&"expirable value"));
@@ -94,5 +94,5 @@ reduce the expiration logic overhead significantly.
 ```rs
 use timed_map::TimedMap;
 
-let mut map: TimedMap<_, _> = TimedMap::new().expiration_tick_cap(500);
+let mut map = TimedMap::new().expiration_tick_cap(500);
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ automatically from the crate internals with `std::time::SystemTime`.
 use timed_map::TimedMap;
 use std::time::Duration;
 
-let mut map: TimedMap<_, _> = TimedMap::default();
+let mut map: TimedMap<_, _> = TimedMap::new();
 
 map.insert_expirable(1, "expirable value", Duration::from_secs(60));
 assert_eq!(map.get(&1), Some(&"expirable value"));
@@ -74,7 +74,7 @@ To have fully control over expired entries, use the `*_unchecked` functions and 
 This can boost performance by running expiration logic only when it's necessary to maximize the performance.
 
 ```rs
-let mut map: TimedMap<_, _> = TimedMap::default();
+let mut map: TimedMap<_, _> = TimedMap::new();
 
 map.insert_expirable_unchecked(1, "expirable value", Duration::from_secs(60));
 assert_eq!(map.get_unchecked(&1), Some(&"expirable value"));
@@ -94,5 +94,5 @@ reduce the expiration logic overhead significantly.
 ```rs
 use timed_map::TimedMap;
 
-let mut map: TimedMap<_, _> = TimedMap::default().expiration_tick_cap(500);
+let mut map: TimedMap<_, _> = TimedMap::new().expiration_tick_cap(500);
 ```

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ automatically from the crate internals with `std::time::SystemTime`.
 
 #### In `std` environments:
 ```rs
-use timed_map::{TimedMap, StdClock};
+use timed_map::TimedMap;
 use std::time::Duration;
 
-let mut map: TimedMap<StdClock, _, _> = TimedMap::new();
+let mut map: TimedMap<_, _> = TimedMap::new();
 
 map.insert_expirable(1, "expirable value", Duration::from_secs(60));
 assert_eq!(map.get(&1), Some(&"expirable value"));
@@ -63,9 +63,9 @@ By default, `TimedMap` uses `BTreeMap` to store data, but you can switch to `FxH
 This is only available on `std` environments.
 
 ```rs
-use timed_map::{MapKind, StdClock, TimedMap};
+use timed_map::{MapKind, TimedMap};
 
-let mut map: TimedMap<StdClock, _, _> = TimedMap::new_with_map_kind(MapKind::FxHashMap);
+let mut map: TimedMap<_, _> = TimedMap::new_with_map_kind(MapKind::FxHashMap);
 ```
 
 #### Manual Expiration Control
@@ -74,7 +74,7 @@ To have fully control over expired entries, use the `*_unchecked` functions and 
 This can boost performance by running expiration logic only when it's necessary to maximize the performance.
 
 ```rs
-let mut map: TimedMap<StdClock, _, _> = TimedMap::new();
+let mut map: TimedMap<_, _> = TimedMap::new();
 
 map.insert_expirable_unchecked(1, "expirable value", Duration::from_secs(60));
 assert_eq!(map.get_unchecked(&1), Some(&"expirable value"));
@@ -92,7 +92,7 @@ if there are 100 inserts per second, setting `expiration_tick_cap` to 100 will t
 reduce the expiration logic overhead significantly.
 
 ```rs
-use timed_map::{TimedMap, StdClock};
+use timed_map::TimedMap;
 
-let mut map: TimedMap<StdClock, _, _> = TimedMap::new().expiration_tick_cap(500);
+let mut map: TimedMap<_, _> = TimedMap::new().expiration_tick_cap(500);
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ automatically from the crate internals with `std::time::SystemTime`.
 use timed_map::TimedMap;
 use std::time::Duration;
 
-let mut map: TimedMap<_, _> = TimedMap::new();
+let mut map: TimedMap<_, _> = TimedMap::default();
 
 map.insert_expirable(1, "expirable value", Duration::from_secs(60));
 assert_eq!(map.get(&1), Some(&"expirable value"));
@@ -74,7 +74,7 @@ To have fully control over expired entries, use the `*_unchecked` functions and 
 This can boost performance by running expiration logic only when it's necessary to maximize the performance.
 
 ```rs
-let mut map: TimedMap<_, _> = TimedMap::new();
+let mut map: TimedMap<_, _> = TimedMap::default();
 
 map.insert_expirable_unchecked(1, "expirable value", Duration::from_secs(60));
 assert_eq!(map.get_unchecked(&1), Some(&"expirable value"));
@@ -94,5 +94,5 @@ reduce the expiration logic overhead significantly.
 ```rs
 use timed_map::TimedMap;
 
-let mut map: TimedMap<_, _> = TimedMap::new().expiration_tick_cap(500);
+let mut map: TimedMap<_, _> = TimedMap::default().expiration_tick_cap(500);
 ```

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -41,8 +41,8 @@ pub struct StdClock {
 }
 
 #[cfg(feature = "std")]
-impl StdClock {
-    pub(crate) fn new() -> Self {
+impl Default for StdClock {
+    fn default() -> Self {
         Self {
             creation: Instant::now(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! use timed_map::TimedMap;
 //! use std::time::Duration;
 //!
-//! let mut map: TimedMap<_, _> = TimedMap::default();
+//! let mut map: TimedMap<_, _> = TimedMap::new();
 //!
 //! map.insert_expirable(1, "expirable value", Duration::from_secs(60));
 //! assert_eq!(map.get(&1), Some(&"expirable value"));
@@ -72,7 +72,7 @@
 //! This can boost performance by running expiration logic only when it's necessary to maximize the performance.
 //!
 //! ```rs
-//! let mut map: TimedMap<_, _> = TimedMap::default();
+//! let mut map: TimedMap<_, _> = TimedMap::new();
 //!
 //! map.insert_expirable_unchecked(1, "expirable value", Duration::from_secs(60));
 //! assert_eq!(map.get_unchecked(&1), Some(&"expirable value"));
@@ -92,7 +92,7 @@
 //! ```rs
 //! use timed_map::TimedMap;
 //!
-//! let mut map: TimedMap<_, _> = TimedMap::default().expiration_tick_cap(500);
+//! let mut map: TimedMap<_, _> = TimedMap::new().expiration_tick_cap(500);
 //! ```
 
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! use timed_map::TimedMap;
 //! use std::time::Duration;
 //!
-//! let mut map: TimedMap<_, _> = TimedMap::new();
+//! let mut map = TimedMap::new();
 //!
 //! map.insert_expirable(1, "expirable value", Duration::from_secs(60));
 //! assert_eq!(map.get(&1), Some(&"expirable value"));
@@ -63,7 +63,7 @@
 //! ```rs
 //! use timed_map::{MapKind, TimedMap};
 //!
-//! let mut map: TimedMap<_, _> = TimedMap::new_with_map_kind(MapKind::FxHashMap);
+//! let mut map = TimedMap::new_with_map_kind(MapKind::FxHashMap);
 //! ```
 //!
 //! #### Manual Expiration Control
@@ -72,7 +72,7 @@
 //! This can boost performance by running expiration logic only when it's necessary to maximize the performance.
 //!
 //! ```rs
-//! let mut map: TimedMap<_, _> = TimedMap::new();
+//! let mut map = TimedMap::new();
 //!
 //! map.insert_expirable_unchecked(1, "expirable value", Duration::from_secs(60));
 //! assert_eq!(map.get_unchecked(&1), Some(&"expirable value"));
@@ -92,7 +92,7 @@
 //! ```rs
 //! use timed_map::TimedMap;
 //!
-//! let mut map: TimedMap<_, _> = TimedMap::new().expiration_tick_cap(500);
+//! let mut map = TimedMap::new().expiration_tick_cap(500);
 //! ```
 
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! use timed_map::TimedMap;
 //! use std::time::Duration;
 //!
-//! let mut map: TimedMap<_, _> = TimedMap::new();
+//! let mut map: TimedMap<_, _> = TimedMap::default();
 //!
 //! map.insert_expirable(1, "expirable value", Duration::from_secs(60));
 //! assert_eq!(map.get(&1), Some(&"expirable value"));
@@ -72,7 +72,7 @@
 //! This can boost performance by running expiration logic only when it's necessary to maximize the performance.
 //!
 //! ```rs
-//! let mut map: TimedMap<_, _> = TimedMap::new();
+//! let mut map: TimedMap<_, _> = TimedMap::default();
 //!
 //! map.insert_expirable_unchecked(1, "expirable value", Duration::from_secs(60));
 //! assert_eq!(map.get_unchecked(&1), Some(&"expirable value"));
@@ -92,7 +92,7 @@
 //! ```rs
 //! use timed_map::TimedMap;
 //!
-//! let mut map: TimedMap<_, _> = TimedMap::new().expiration_tick_cap(500);
+//! let mut map: TimedMap<_, _> = TimedMap::default().expiration_tick_cap(500);
 //! ```
 
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@
 //!
 //! #### In `std` environments:
 //! ```rs
-//! use timed_map::{TimedMap, StdClock};
+//! use timed_map::TimedMap;
 //! use std::time::Duration;
 //!
-//! let mut map: TimedMap<StdClock, _, _> = TimedMap::new();
+//! let mut map: TimedMap<_, _> = TimedMap::new();
 //!
 //! map.insert_expirable(1, "expirable value", Duration::from_secs(60));
 //! assert_eq!(map.get(&1), Some(&"expirable value"));
@@ -61,9 +61,9 @@
 //! This is only available on `std` environments.
 //!
 //! ```rs
-//! use timed_map::{MapKind, StdClock, TimedMap};
+//! use timed_map::{MapKind, TimedMap};
 //!
-//! let mut map: TimedMap<StdClock, _, _> = TimedMap::new_with_map_kind(MapKind::FxHashMap);
+//! let mut map: TimedMap<_, _> = TimedMap::new_with_map_kind(MapKind::FxHashMap);
 //! ```
 //!
 //! #### Manual Expiration Control
@@ -72,7 +72,7 @@
 //! This can boost performance by running expiration logic only when it's necessary to maximize the performance.
 //!
 //! ```rs
-//! let mut map: TimedMap<StdClock, _, _> = TimedMap::new();
+//! let mut map: TimedMap<_, _> = TimedMap::new();
 //!
 //! map.insert_expirable_unchecked(1, "expirable value", Duration::from_secs(60));
 //! assert_eq!(map.get_unchecked(&1), Some(&"expirable value"));
@@ -90,9 +90,9 @@
 //! reduce the expiration logic overhead significantly.
 //!
 //! ```rs
-//! use timed_map::{TimedMap, StdClock};
+//! use timed_map::TimedMap;
 //!
-//! let mut map: TimedMap<StdClock, _, _> = TimedMap::new().expiration_tick_cap(500);
+//! let mut map: TimedMap<_, _> = TimedMap::new().expiration_tick_cap(500);
 //! ```
 
 #![no_std]
@@ -122,7 +122,6 @@ macro_rules! cfg_not_std_feature {
 cfg_std_feature! {
     extern crate std;
 
-    use std::marker::PhantomData;
     use std::time::Duration;
     use std::collections::{BTreeMap, HashMap};
     use std::hash::Hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,6 @@ cfg_std_feature! {
     use std::collections::{BTreeMap, HashMap};
     use std::hash::Hash;
     use std::vec::Vec;
-    use clock::Clock;
 
     #[cfg(not(feature = "wasm"))]
     use std::time::Instant;
@@ -134,7 +133,7 @@ cfg_std_feature! {
     #[cfg(feature = "wasm")]
     use web_time::Instant;
 
-    pub use clock::StdClock;
+    pub use clock::{Clock, StdClock};
     pub use map::MapKind;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ cfg_std_feature! {
     use std::collections::{BTreeMap, HashMap};
     use std::hash::Hash;
     use std::vec::Vec;
+    use clock::{Clock, StdClock};
 
     #[cfg(not(feature = "wasm"))]
     use std::time::Instant;
@@ -133,7 +134,6 @@ cfg_std_feature! {
     #[cfg(feature = "wasm")]
     use web_time::Instant;
 
-    pub use clock::{Clock, StdClock};
     pub use map::MapKind;
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -222,6 +222,24 @@ where
     C: Clock,
     K: GenericKey,
 {
+    #[cfg(feature = "std")]
+    pub fn new_with_clock_and_map_kind(clock: C, map_kind: MapKind) -> Self {
+        let map = match map_kind {
+            MapKind::BTreeMap => GenericMap::<K, ExpirableEntry<V>>::BTreeMap(BTreeMap::default()),
+            MapKind::HashMap => GenericMap::HashMap(HashMap::default()),
+            #[cfg(feature = "rustc-hash")]
+            MapKind::FxHashMap => GenericMap::FxHashMap(FxHashMap::default()),
+        };
+
+        Self {
+            map,
+            clock,
+            expiries: BTreeMap::default(),
+            expiration_tick: 0,
+            expiration_tick_cap: 1,
+        }
+    }
+
     /// Creates an empty `TimedMap`.
     ///
     /// Uses the provided `clock` to handle expiration times.

--- a/src/map.rs
+++ b/src/map.rs
@@ -222,24 +222,6 @@ where
     C: Clock,
     K: GenericKey,
 {
-    #[cfg(feature = "std")]
-    pub fn new_with_clock_and_map_kind(clock: C, map_kind: MapKind) -> Self {
-        let map = match map_kind {
-            MapKind::BTreeMap => GenericMap::<K, ExpirableEntry<V>>::BTreeMap(BTreeMap::default()),
-            MapKind::HashMap => GenericMap::HashMap(HashMap::default()),
-            #[cfg(feature = "rustc-hash")]
-            MapKind::FxHashMap => GenericMap::FxHashMap(FxHashMap::default()),
-        };
-
-        Self {
-            map,
-            clock,
-            expiries: BTreeMap::default(),
-            expiration_tick: 0,
-            expiration_tick_cap: 1,
-        }
-    }
-
     /// Creates an empty `TimedMap`.
     ///
     /// Uses the provided `clock` to handle expiration times.

--- a/src/map.rs
+++ b/src/map.rs
@@ -191,12 +191,6 @@ where
     C: Clock + Default,
     K: GenericKey,
 {
-    /// Creates an empty map.
-    #[cfg(feature = "std")]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Creates an empty map based on the chosen map implementation specified by `MapKind`.
     #[cfg(feature = "std")]
     pub fn new_with_map_kind(map_kind: MapKind) -> Self {
@@ -221,7 +215,6 @@ where
     /// Creates an empty `TimedMap`.
     ///
     /// Uses the provided `clock` to handle expiration times.
-    #[cfg(not(feature = "std"))]
     pub fn new(clock: C) -> Self {
         Self {
             clock,
@@ -594,7 +587,7 @@ mod std_tests {
 
     #[test]
     fn std_expirable_and_constant_entries() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map: TimedMap<u32, &str> = TimedMap::default();
 
         map.insert_constant(1, "constant value");
         map.insert_expirable(2, "expirable value", Duration::from_secs(2));
@@ -608,7 +601,7 @@ mod std_tests {
 
     #[test]
     fn std_expired_entry_removal() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map: TimedMap<u32, &str> = TimedMap::default();
         let duration = Duration::from_secs(2);
 
         map.insert_expirable(1, "expirable value", duration);
@@ -623,7 +616,7 @@ mod std_tests {
 
     #[test]
     fn std_remove_entry() {
-        let mut map: TimedMap<_, _> = TimedMap::new();
+        let mut map: TimedMap<_, _> = TimedMap::default();
 
         map.insert_constant(1, "constant value");
         map.insert_expirable(2, "expirable value", Duration::from_secs(2));
@@ -637,7 +630,7 @@ mod std_tests {
 
     #[test]
     fn std_drop_expired_entries() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map: TimedMap<u32, &str> = TimedMap::default();
 
         map.insert_expirable(1, "expirable value1", Duration::from_secs(2));
         map.insert_expirable(2, "expirable value2", Duration::from_secs(4));
@@ -652,7 +645,7 @@ mod std_tests {
 
     #[test]
     fn std_update_existing_entry() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map: TimedMap<u32, &str> = TimedMap::default();
 
         map.insert_constant(1, "initial value");
         assert_eq!(map.get(&1), Some(&"initial value"));
@@ -669,7 +662,7 @@ mod std_tests {
 
     #[test]
     fn std_insert_constant_and_expirable_combined() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map: TimedMap<u32, &str> = TimedMap::default();
 
         // Insert a constant entry and an expirable entry
         map.insert_constant(1, "constant value");
@@ -689,7 +682,7 @@ mod std_tests {
 
     #[test]
     fn std_expirable_entry_still_valid_before_expiration() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map: TimedMap<u32, &str> = TimedMap::default();
 
         // Insert an expirable entry with a duration of 60 seconds
         map.insert_expirable(1, "expirable value", Duration::from_secs(3));

--- a/src/map.rs
+++ b/src/map.rs
@@ -192,6 +192,11 @@ where
     C: Clock + Default,
     K: GenericKey,
 {
+    /// Creates an empty map.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Creates an empty map based on the chosen map implementation specified by `MapKind`.
     pub fn new_with_map_kind(map_kind: MapKind) -> Self {
         let map = match map_kind {
@@ -221,6 +226,7 @@ where
     /// Creates an empty `TimedMap`.
     ///
     /// Uses the provided `clock` to handle expiration times.
+    #[cfg(not(feature = "std"))]
     pub fn new(clock: C) -> Self {
         Self {
             clock,
@@ -592,7 +598,7 @@ mod std_tests {
 
     #[test]
     fn std_expirable_and_constant_entries() {
-        let mut map: TimedMap<u32, &str> = TimedMap::default();
+        let mut map: TimedMap<u32, &str> = TimedMap::new();
 
         map.insert_constant(1, "constant value");
         map.insert_expirable(2, "expirable value", Duration::from_secs(2));
@@ -606,7 +612,7 @@ mod std_tests {
 
     #[test]
     fn std_expired_entry_removal() {
-        let mut map: TimedMap<u32, &str> = TimedMap::default();
+        let mut map: TimedMap<u32, &str> = TimedMap::new();
         let duration = Duration::from_secs(2);
 
         map.insert_expirable(1, "expirable value", duration);
@@ -621,7 +627,7 @@ mod std_tests {
 
     #[test]
     fn std_remove_entry() {
-        let mut map: TimedMap<_, _> = TimedMap::default();
+        let mut map: TimedMap<_, _> = TimedMap::new();
 
         map.insert_constant(1, "constant value");
         map.insert_expirable(2, "expirable value", Duration::from_secs(2));
@@ -635,7 +641,7 @@ mod std_tests {
 
     #[test]
     fn std_drop_expired_entries() {
-        let mut map: TimedMap<u32, &str> = TimedMap::default();
+        let mut map: TimedMap<u32, &str> = TimedMap::new();
 
         map.insert_expirable(1, "expirable value1", Duration::from_secs(2));
         map.insert_expirable(2, "expirable value2", Duration::from_secs(4));
@@ -650,7 +656,7 @@ mod std_tests {
 
     #[test]
     fn std_update_existing_entry() {
-        let mut map: TimedMap<u32, &str> = TimedMap::default();
+        let mut map: TimedMap<u32, &str> = TimedMap::new();
 
         map.insert_constant(1, "initial value");
         assert_eq!(map.get(&1), Some(&"initial value"));
@@ -667,7 +673,7 @@ mod std_tests {
 
     #[test]
     fn std_insert_constant_and_expirable_combined() {
-        let mut map: TimedMap<u32, &str> = TimedMap::default();
+        let mut map: TimedMap<u32, &str> = TimedMap::new();
 
         // Insert a constant entry and an expirable entry
         map.insert_constant(1, "constant value");
@@ -687,7 +693,7 @@ mod std_tests {
 
     #[test]
     fn std_expirable_entry_still_valid_before_expiration() {
-        let mut map: TimedMap<u32, &str> = TimedMap::default();
+        let mut map: TimedMap<u32, &str> = TimedMap::new();
 
         // Insert an expirable entry with a duration of 60 seconds
         map.insert_expirable(1, "expirable value", Duration::from_secs(3));

--- a/src/map.rs
+++ b/src/map.rs
@@ -493,7 +493,7 @@ mod tests {
     #[test]
     fn nostd_insert_and_get_constant_entry() {
         let clock = MockClock { current_time: 1000 };
-        let mut map: TimedMap<u32, &str, _> = TimedMap::new(clock);
+        let mut map = TimedMap::new(clock);
 
         map.insert_constant(1, "constant value");
 
@@ -504,7 +504,7 @@ mod tests {
     #[test]
     fn nostd_insert_and_get_expirable_entry() {
         let clock = MockClock { current_time: 1000 };
-        let mut map: TimedMap<u32, &str, _> = TimedMap::new(clock);
+        let mut map = TimedMap::new(clock);
         let duration = Duration::from_secs(60);
 
         map.insert_expirable(1, "expirable value", duration);
@@ -516,7 +516,7 @@ mod tests {
     #[test]
     fn nostd_expired_entry() {
         let clock = MockClock { current_time: 1000 };
-        let mut map: TimedMap<u32, &str, _> = TimedMap::new(clock);
+        let mut map = TimedMap::new(clock);
         let duration = Duration::from_secs(60);
 
         // Insert entry that expires in 60 seconds
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn nostd_remove_entry() {
         let clock = MockClock { current_time: 1000 };
-        let mut map: TimedMap<u32, &str, _> = TimedMap::new(clock);
+        let mut map = TimedMap::new(clock);
 
         map.insert_constant(1, "constant value");
 
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn nostd_drop_expired_entries() {
         let clock = MockClock { current_time: 1000 };
-        let mut map: TimedMap<u32, &str, _> = TimedMap::new(clock);
+        let mut map = TimedMap::new(clock);
 
         // Insert one constant and 2 expirable entries
         map.insert_expirable(1, "expirable value1", Duration::from_secs(50));
@@ -573,7 +573,7 @@ mod tests {
     #[test]
     fn nostd_update_existing_entry() {
         let clock = MockClock { current_time: 1000 };
-        let mut map: TimedMap<u32, &str, _> = TimedMap::new(clock);
+        let mut map = TimedMap::new(clock);
 
         map.insert_constant(1, "initial value");
         assert_eq!(map.get(&1), Some(&"initial value"));

--- a/src/map.rs
+++ b/src/map.rs
@@ -187,9 +187,8 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<K, V, C> TimedMap<K, V, C>
+impl<K, V> TimedMap<K, V, StdClock>
 where
-    C: Clock + Default,
     K: GenericKey,
 {
     /// Creates an empty map.
@@ -209,7 +208,7 @@ where
         Self {
             map,
 
-            clock: C::default(),
+            clock: StdClock::default(),
             expiries: BTreeMap::default(),
 
             expiration_tick: 0,
@@ -598,7 +597,7 @@ mod std_tests {
 
     #[test]
     fn std_expirable_and_constant_entries() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map = TimedMap::new();
 
         map.insert_constant(1, "constant value");
         map.insert_expirable(2, "expirable value", Duration::from_secs(2));
@@ -612,7 +611,7 @@ mod std_tests {
 
     #[test]
     fn std_expired_entry_removal() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map = TimedMap::new();
         let duration = Duration::from_secs(2);
 
         map.insert_expirable(1, "expirable value", duration);
@@ -627,7 +626,7 @@ mod std_tests {
 
     #[test]
     fn std_remove_entry() {
-        let mut map: TimedMap<_, _> = TimedMap::new();
+        let mut map = TimedMap::new();
 
         map.insert_constant(1, "constant value");
         map.insert_expirable(2, "expirable value", Duration::from_secs(2));
@@ -641,7 +640,7 @@ mod std_tests {
 
     #[test]
     fn std_drop_expired_entries() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map = TimedMap::new();
 
         map.insert_expirable(1, "expirable value1", Duration::from_secs(2));
         map.insert_expirable(2, "expirable value2", Duration::from_secs(4));
@@ -656,7 +655,7 @@ mod std_tests {
 
     #[test]
     fn std_update_existing_entry() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map = TimedMap::new();
 
         map.insert_constant(1, "initial value");
         assert_eq!(map.get(&1), Some(&"initial value"));
@@ -673,7 +672,7 @@ mod std_tests {
 
     #[test]
     fn std_insert_constant_and_expirable_combined() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map = TimedMap::new();
 
         // Insert a constant entry and an expirable entry
         map.insert_constant(1, "constant value");
@@ -693,7 +692,7 @@ mod std_tests {
 
     #[test]
     fn std_expirable_entry_still_valid_before_expiration() {
-        let mut map: TimedMap<u32, &str> = TimedMap::new();
+        let mut map = TimedMap::new();
 
         // Insert an expirable entry with a duration of 60 seconds
         map.insert_expirable(1, "expirable value", Duration::from_secs(3));

--- a/src/map.rs
+++ b/src/map.rs
@@ -186,13 +186,13 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<K, V, C> TimedMap<K, V, C>
 where
     C: Clock + Default,
     K: GenericKey,
 {
     /// Creates an empty map based on the chosen map implementation specified by `MapKind`.
-    #[cfg(feature = "std")]
     pub fn new_with_map_kind(map_kind: MapKind) -> Self {
         let map = match map_kind {
             MapKind::BTreeMap => GenericMap::<K, ExpirableEntry<V>>::BTreeMap(BTreeMap::default()),
@@ -211,7 +211,13 @@ where
             expiration_tick_cap: 1,
         }
     }
+}
 
+impl<K, V, C> TimedMap<K, V, C>
+where
+    C: Clock,
+    K: GenericKey,
+{
     /// Creates an empty `TimedMap`.
     ///
     /// Uses the provided `clock` to handle expiration times.
@@ -469,7 +475,6 @@ where
 mod tests {
     use super::*;
 
-    #[derive(Default)]
     struct MockClock {
         current_time: u64,
     }


### PR DESCRIPTION
but this clock defaults to `StdClock` as a sane default. The user can still provide any arbitrary clock they want to provide.
This bridges up some visible gap in std vs no-std code (namely removes the phantom typer and the concrete `clock` field)

Suggest to review each commit on its own.