### PR TITLE
serde support and `1.4` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,13 @@ keywords = ["map", "no_std"]
 doctest = false
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 rustc-hash = ["dep:rustc-hash"]
+serde = ["dep:serde"]
 std = []
 wasm = ["dep:web-time"]
 
 [dependencies]
 rustc-hash = { version = "2.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 web-time = { version = "1.1", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "timed-map"
 description = "Lightweight map implementation that supports expiring entries and fully compatible with both std and no_std environments."
-version = "1.3.2"
+version = "1.4.0"
 edition = "2021"
 authors = ["Onur Ozkan <contact@onurozkan.dev>"]
 license = "MIT"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -92,6 +92,16 @@ impl<V> ExpirableEntry<V> {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<V: serde::Serialize> serde::Serialize for ExpirableEntry<V> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.value.serialize(serializer)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/map.rs
+++ b/src/map.rs
@@ -169,6 +169,22 @@ pub struct TimedMap<K, V, #[cfg(feature = "std")] C = StdClock, #[cfg(not(featur
     expiration_tick_cap: u16,
 }
 
+#[cfg(feature = "serde")]
+impl<K: serde::Serialize + Ord, V: serde::Serialize, C> serde::Serialize for TimedMap<K, V, C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.map {
+            GenericMap::BTreeMap(inner) => serializer.collect_map(inner),
+            #[cfg(feature = "std")]
+            GenericMap::HashMap(inner) => serializer.collect_map(inner),
+            #[cfg(all(feature = "std", feature = "rustc-hash"))]
+            GenericMap::FxHashMap(inner) => serializer.collect_map(inner),
+        }
+    }
+}
+
 impl<K, V, C> Default for TimedMap<K, V, C>
 where
     C: Default,


### PR DESCRIPTION
self-explanatory