### PR TITLE
implement iterations and return expirable entries

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -35,7 +35,7 @@ pub trait Clock {
 /// When `std` is enabled, this is automatically utilized in `TimedMap`
 /// to avoid requiring users to implement the `Clock` trait themselves.
 #[cfg(feature = "std")]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StdClock {
     creation: Instant,
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -26,7 +26,7 @@ impl EntryStatus {
 
 /// The entry holds a value `V` and an associated `EntryStatus` which determines
 /// whether the entry is constant or expirable.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct ExpirableEntry<V> {
     value: V,
     status: EntryStatus,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -18,6 +18,15 @@ pub(crate) enum GenericMapIterMut<'a, K, V> {
     FxHashMap(hash_map::IterMut<'a, K, V>),
 }
 
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum GenericMapIntoIter<K, V> {
+    BTreeMap(btree_map::IntoIter<K, V>),
+    #[cfg(feature = "std")]
+    HashMap(hash_map::IntoIter<K, V>),
+    #[cfg(all(feature = "std", feature = "rustc-hash"))]
+    FxHashMap(hash_map::IntoIter<K, V>),
+}
+
 impl<'a, K, V> Iterator for GenericMapIter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
@@ -34,6 +43,20 @@ impl<'a, K, V> Iterator for GenericMapIter<'a, K, V> {
 
 impl<'a, K, V> Iterator for GenericMapIterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTreeMap(iter) => iter.next(),
+            #[cfg(feature = "std")]
+            Self::HashMap(iter) => iter.next(),
+            #[cfg(all(feature = "std", feature = "rustc-hash"))]
+            Self::FxHashMap(iter) => iter.next(),
+        }
+    }
+}
+
+impl<K, V> Iterator for GenericMapIntoIter<K, V> {
+    type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,45 @@
+use super::*;
+
+pub(crate) enum GenericMapIter<'a, K, V> {
+    BTreeMap(btree_map::Iter<'a, K, V>),
+    #[cfg(feature = "std")]
+    HashMap(hash_map::Iter<'a, K, V>),
+    #[cfg(all(feature = "std", feature = "rustc-hash"))]
+    FxHashMap(hash_map::Iter<'a, K, V>),
+}
+
+pub(crate) enum GenericMapIterMut<'a, K, V> {
+    BTreeMap(btree_map::IterMut<'a, K, V>),
+    #[cfg(feature = "std")]
+    HashMap(hash_map::IterMut<'a, K, V>),
+    #[cfg(all(feature = "std", feature = "rustc-hash"))]
+    FxHashMap(hash_map::IterMut<'a, K, V>),
+}
+
+impl<'a, K, V> Iterator for GenericMapIter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTreeMap(iter) => iter.next(),
+            #[cfg(feature = "std")]
+            Self::HashMap(iter) => iter.next(),
+            #[cfg(all(feature = "std", feature = "rustc-hash"))]
+            Self::FxHashMap(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'a, K, V> Iterator for GenericMapIterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BTreeMap(iter) => iter.next(),
+            #[cfg(feature = "std")]
+            Self::HashMap(iter) => iter.next(),
+            #[cfg(all(feature = "std", feature = "rustc-hash"))]
+            Self::FxHashMap(iter) => iter.next(),
+        }
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum GenericMapIter<'a, K, V> {
     BTreeMap(btree_map::Iter<'a, K, V>),
     #[cfg(feature = "std")]
@@ -8,6 +9,7 @@ pub(crate) enum GenericMapIter<'a, K, V> {
     FxHashMap(hash_map::Iter<'a, K, V>),
 }
 
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum GenericMapIterMut<'a, K, V> {
     BTreeMap(btree_map::IterMut<'a, K, V>),
     #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ cfg_std_feature! {
     use std::time::Duration;
     use std::collections::{btree_map, hash_map, BTreeMap, HashMap, BTreeSet};
     use std::hash::Hash;
-    use std::vec::Vec;
+    use std::vec::{Vec, IntoIter};
     use clock::{Clock, StdClock};
 
     #[cfg(not(feature = "wasm"))]
@@ -142,7 +142,7 @@ cfg_not_std_feature! {
     extern crate alloc;
 
     use core::time::Duration;
-    use alloc::vec::Vec;
+    use alloc::vec::{Vec, IntoIter};
     use alloc::collections::{btree_map, BTreeMap, BTreeSet};
 
     pub use clock::Clock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@
 
 mod clock;
 mod entry;
+mod iter;
 mod map;
 
 macro_rules! cfg_std_feature {
@@ -123,7 +124,7 @@ cfg_std_feature! {
     extern crate std;
 
     use std::time::Duration;
-    use std::collections::{BTreeMap, HashMap, BTreeSet};
+    use std::collections::{btree_map, hash_map, BTreeMap, HashMap, BTreeSet};
     use std::hash::Hash;
     use std::vec::Vec;
     use clock::{Clock, StdClock};
@@ -142,7 +143,7 @@ cfg_not_std_feature! {
 
     use core::time::Duration;
     use alloc::vec::Vec;
-    use alloc::collections::{BTreeMap, BTreeSet};
+    use alloc::collections::{btree_map, BTreeMap, BTreeSet};
 
     pub use clock::Clock;
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -219,7 +219,6 @@ impl<K: serde::Serialize + Ord, V: serde::Serialize, C: Clock> serde::Serialize
     }
 }
 
-
 impl<'a, K, V, C> IntoIterator for &'a TimedMap<K, V, C>
 where
     K: GenericKey,

--- a/src/map.rs
+++ b/src/map.rs
@@ -34,7 +34,7 @@ cfg_std_feature! {
 
 /// Wraps different map implementations and provides a single interface to access them.
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum GenericMap<K, V> {
     BTreeMap(BTreeMap<K, V>),
     #[cfg(feature = "std")]
@@ -158,7 +158,7 @@ pub enum MapKind {
 /// Mutable functions automatically clears expired entries when called.
 ///
 /// If no expiration is set, the entry remains constant.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TimedMap<K, V, #[cfg(feature = "std")] C = StdClock, #[cfg(not(feature = "std"))] C> {
     clock: C,
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -225,7 +225,7 @@ where
     C: Clock,
 {
     type Item = (&'a K, &'a V);
-    type IntoIter = std::vec::IntoIter<(&'a K, &'a V)>;
+    type IntoIter = IntoIter<(&'a K, &'a V)>;
 
     fn into_iter(self) -> Self::IntoIter {
         let now = self.clock.elapsed_seconds_since_creation();
@@ -250,7 +250,7 @@ where
     C: Clock,
 {
     type Item = (&'a K, &'a mut V);
-    type IntoIter = std::vec::IntoIter<(&'a K, &'a mut V)>;
+    type IntoIter = IntoIter<(&'a K, &'a mut V)>;
 
     fn into_iter(self) -> Self::IntoIter {
         let now = self.clock.elapsed_seconds_since_creation();
@@ -276,7 +276,7 @@ where
     C: Clock,
 {
     type Item = (K, V);
-    type IntoIter = std::vec::IntoIter<(K, V)>;
+    type IntoIter = IntoIter<(K, V)>;
 
     fn into_iter(self) -> Self::IntoIter {
         let now = self.clock.elapsed_seconds_since_creation();


### PR DESCRIPTION
Brings bunch of different things that can be documented in 3 categories:

**Iterations**

This adds iterator support to `TimedMap`. You can now use `for` loops and `.into_iter()` on `TimedMap` just like regular maps. It skips expired entries by default.

Also added `iter_unchecked()` and `iter_mut_unchecked()` if you want to exclude expired entries.

**Returning expired entries**

`drop_expired_entries()` now returns the removed entries instead of just dropping them silently.

**Minor changes**

Lastly, derived `Clone` for a few types to make them easier to use.